### PR TITLE
Support Ayatana Indicators and Ubuntu Indicators

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -19,24 +19,173 @@ PKG_CHECK_MODULES(BUDGIE_PLUGIN,
         budgie-1.0 >= budgie_required_version
 )
 
-INDICATOR_API_VERSION=3
-INDICATOR_REQUIRED_VERSION=0.3.90
-INDICATOR_NG_VERSION=0.5
-INDICATOR_PKG=indicator$INDICATOR_API_VERSION-0.4
+UBUNTU_INDICATOR_API_VERSION=3
+UBUNTU_INDICATOR_REQUIRED_VERSION=0.3.90
+UBUNTU_INDICATOR_NG_VERSION=0.5
+UBUNTU_INDICATOR_PKG=indicator$INDICATOR_API_VERSION-0.4
 
-PKG_CHECK_MODULES(INDICATOR, $INDICATOR_PKG >= $INDICATOR_NG_VERSION
-                      libido3-0.1 >= 0.3.4,
-                      [AC_DEFINE(HAVE_INDICATOR_NG, 1, "New style indicators support")])
-                      
-AC_SUBST(INDICATOR_CFLAGS)
-AC_SUBST(INDICATOR_LIBS)
+AYATANA_INDICATOR_API_VERSION=3
+AYATANA_INDICATOR_REQUIRED_VERSION=0.6.0
+AYATANA_INDICATOR_NG_VERSION=0.6.0
+AYATANA_INDICATOR_PKG=ayatana-indicator$INDICATOR_API_VERSION-0.4
 
-INDICATORDIR=`$PKG_CONFIG --variable=indicatordir $INDICATOR_PKG`
-INDICATORICONSDIR=`$PKG_CONFIG --variable=iconsdir $INDICATOR_PKG`
+AC_ARG_WITH([ayatana-indicators],
+             [AS_HELP_STRING([--with-ayatana-indicators],
+                             [build against Ayatana Indicators])],
+             [with_ayatana_indicators='yes'],
+             [with_ayatana_indicators='no']
+)
+
+AC_ARG_WITH([ubuntu-indicators],
+             [AS_HELP_STRING([--with-ubuntu-indicators],
+             [build against Ubuntu Indicators])],
+             [with_ubuntu_indicators='yes'],
+             [with_ubuntu_indicators='no']
+)
+
+###
+### Look for Ayatana Indicators
+###
+
+PKG_CHECK_EXISTS(ayatana-indicator3-0.4,
+                 [have_ayatanaindicator="yes"],
+                 [have_ayatanaindicator="no"])
+
+PKG_CHECK_EXISTS(ayatana-indicator3-0.4 >= $AYATANA_INDICATOR_NG_VERSION,
+                 [have_ayatanaindicator_ng="yes"],
+                 [have_ayatanaindicator_ng="no"])
+
+###
+### Look for Ubuntu Indicators
+###
+
+PKG_CHECK_EXISTS(indicator3-0.4,
+                 [have_ubuntuindicator="yes"],
+                 [have_ubuntuindicator="no"])
+
+PKG_CHECK_EXISTS(indicator3-0.4 >= $UBUNTU_INDICATOR_NG_VERSION,
+                 [have_ubuntuindicator_ng="yes"],
+                 [have_ubuntuindicator_ng="no"])
+
+### decide on what Indicators implementation to use...
+
+if   test "x$have_ayatanaindicator" == "xyes" &&
+     test "x$have_ubuntuindicator" != "xyes" &&
+     test "x$with_ubuntu_indicators" != "xyes"; then
+
+    # use Ayatana Indicators (because they are present, and noone is enforcing Ubuntu Indicators)
+    use_ayatanaindicator="yes";
+    indicator_enforced="no";
+
+elif test "x$have_ubuntuindicator" == "xyes" &&
+     test "x$have_ayatanaindicator" != "xyes" &&
+     test "x$with_ayatana_indicators" != "xyes"; then
+
+    # use Ubuntu Indicators (because they are present, and noone is enforcing Ayatana Indicators)
+    use_ubuntuindicator="yes";
+    indicator_enforced="no";
+
+elif test "x$have_ubuntuindicator" == "xyes" &&
+     test "x$have_ayatanaindicator" == "xyes" &&
+     test "x$with_ayatana_indicators" == "xyes"; then
+
+    # both Indicator implementations are present, and we are asked to use Ayatana Indicators
+    use_ayatanaindicator=yes;
+    indicator_enforced=yes;
+
+elif test "x$have_ubuntuindicator" == "xyes" &&
+     test "x$have_ayatanaindicator" == "xyes" &&
+     test "x$with_ubuntu_indicators" == "xyes"; then
+
+    # both Indicator implementations are present, and we are asked to use Ubuntu Indicators
+    use_ubuntuindicator=yes;
+    indicator_enforced=yes;
+
+elif test "x$have_ubuntuindicator" == "xyes" &&
+     test "x$have_ayatanaindicator" != "xyes" &&
+     test "x$with_ayatana_indicators" == "xyes"; then
+
+    AC_MSG_ERROR([Ubuntu Indicators are present, but you want to build budgie-indicator-applet against Ayatana Indicators. This does not match.])
+
+elif test "x$have_ubuntuindicator" != "xyes" &&
+     test "x$have_ayatanaindicator" == "xyes" &&
+     test "x$with_ubuntu_indicators" == "xyes"; then
+
+    AC_MSG_ERROR([Ayatana Indicators are present, but you want to build budgie-indicator-applet against Ubuntu Indicators. This does not match.])
+
+else
+
+    AC_MSG_ERROR([Either Ayatana Indicators or Ubuntu Indicators are required to build budgie-indicator-applet.])
+
+fi
+
+### prepare Ayatana or Ubuntu Indicators implementation for the build, regarding to the decision reached above...
+
+if   test "x$use_ayatanaindicator" == "xyes"; then
+
+    AM_CONDITIONAL(WITH_AYATANA_INDICATOR, true)
+    AM_CONDITIONAL(WITH_UBUNTU_INDICATOR, false)
+    AC_DEFINE(HAVE_AYATANA_INDICATOR, 1, "Ayatana Indicators Support")
+    AC_DEFINE(HAVE_UBUNTU_INDICATOR, 0, "DISABLED: Ubuntu Indicators Support")
+    AC_DEFINE(HAVE_UBUNTU_INDICATOR_NG, 0, "DISABLED: Ubuntu Indicators NG Support")
+
+    if test "x$indicator_enforced" == "xyes"; then
+        AC_MSG_NOTICE([Using Ayatana Indicators for this build (as requested via configure option).])
+    else
+        AC_MSG_NOTICE([Using Ayatana Indicators for this build.])
+    fi
+
+    if test "x$have_ayatanaindicator_ng" = "xyes"; then
+        PKG_CHECK_MODULES(AYATANA_INDICATOR_NG, ayatana-indicator3-0.4 >= $AYATANA_INDICATOR_NG_VERSION
+                          libayatana-ido3-0.4 >= 0.4.0,
+                          [AC_DEFINE(HAVE_AYATANA_INDICATOR_NG, 1, "New style indicators support")])
+    elif test "x$have_ayatanaindicator" = "xyes"; then
+        PKG_CHECK_MODULES(AYATANA_INDICATOR, ayatana-indicator3-0.4 >= $AYATANA_INDICATOR_REQUIRED_VERSION)
+    fi
+
+    AC_SUBST(AYATANA_INDICATOR_CFLAGS)
+    AC_SUBST(AYATANA_INDICATOR_LIBS)
+
+elif test "x$use_ubuntuindicator" == "xyes"; then
+
+    # both Indicator implementations are present, and we are asked to use Ubuntu Indicators
+    AM_CONDITIONAL(WITH_UBUNTU_INDICATOR, true)
+    AM_CONDITIONAL(WITH_AYATANA_INDICATOR, false)
+    AC_DEFINE(HAVE_UBUNTU_INDICATOR, 1, "Ubuntu Indicators Support")
+    AC_DEFINE(HAVE_AYATANA_INDICATOR, 0, "No Ayatana Indicators Support")
+    AC_DEFINE(HAVE_AYATANA_INDICATOR_NG, 0, "No Ayatana Indicators NG Support")
+
+    if test "x$indicator_enforced" == "xyes"; then
+        AC_MSG_NOTICE([Using Ubuntu Indicators for this build (as requested via configure option).])
+    else
+        AC_MSG_NOTICE([Using Ubuntu Indicators for this build.])
+    fi
+
+    if test "x$have_ubuntuindicator_ng" = "xyes"; then
+        PKG_CHECK_MODULES(UBUNTU_INDICATOR_NG, indicator3-0.4 >= $UBUNTU_INDICATOR_NG_VERSION
+                          libido3-0.1 >= 13.10,
+                          [AC_DEFINE(HAVE_UBUNTU_INDICATOR_NG, 1, "New style indicators support")])
+    elif test "x$have_ubuntuindicator" = "xyes"; then
+        PKG_CHECK_MODULES(UBUNTU_INDICATOR, indicator3-0.4 >= $UBUNTU_INDICATOR_REQUIRED_VERSION)
+    fi
+
+    AC_SUBST(UBUNTU_INDICATOR_CFLAGS)
+    AC_SUBST(UBUNTU_INDICATOR_LIBS)
+
+fi
+
+if test "x$use_ubuntuindicator" = "xyes"; then
+       INDICATORDIR=`$PKG_CONFIG --variable=indicatordir indicator3-0.4`
+       INDICATORICONSDIR=`$PKG_CONFIG --variable=iconsdir indicator3-0.4`
+fi
+
+if test "x$use_ayatanaindicator" = "xyes"; then
+       INDICATORDIR=`$PKG_CONFIG --variable=indicatordir ayatana-indicator3-0.4`
+       INDICATORICONSDIR=`$PKG_CONFIG --variable=iconsdir ayatana-indicator3-0.4`
+fi
 
 AC_SUBST(INDICATORDIR)
 AC_SUBST(INDICATORICONSDIR)
-
 
 AC_CONFIG_FILES([Makefile
                  src/Makefile])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,3 +1,17 @@
+if WITH_AYATANA_INDICATOR
+INDICATOR_CFLAGS = $(AYATANA_INDICATOR_CFLAGS)          \
+                   $(AYATANA_INDICATOR_NG_CFLAGS)
+INDICATOR_LIBS   = $(AYATANA_INDICATOR_LIBS)            \
+                   $(AYATANA_INDICATOR_NG_LIBS)
+endif
+
+if WITH_UBUNTU_INDICATOR
+INDICATOR_CFLAGS = $(UBUNTU_INDICATOR_CFLAGS)           \
+                   $(UBUNTU_INDICATOR_NG_CFLAGS)
+INDICATOR_LIBS   = $(UBUNTU_INDICATOR_LIBS)             \
+                   $(UBUNTU_INDICATOR_NG_LIBS)
+endif
+
 include $(top_srcdir)/common.mk
 
 plugindir = $(libdir)/budgie-desktop/plugins

--- a/src/applet-main.c
+++ b/src/applet-main.c
@@ -28,19 +28,17 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <budgie-desktop/plugin.h>
 
-//#if HAVE_UBUNTU_INDICATOR && HAVE_UBUNTU_INDICATOR_NG
-//#include <libindicator/indicator-ng.h>
-//#include <libido/libido.h>
-//
-//#define INDICATOR_SERVICE_DIR "/usr/share/unity/indicators"
-//#endif
+#if HAVE_UBUNTU_INDICATOR && HAVE_UBUNTU_INDICATOR_NG
+#include <libindicator/indicator-ng.h>
 
-//#if HAVE_AYATANA_INDICATOR && HAVE_AYATANA_INDICATOR_NG
-//#include <libayatana-indicator/indicator-ng.h>
-//#include <libayatana-ido/libayatana-ido.h>
-//
-//#define INDICATOR_SERVICE_DIR "/usr/share/ayatana/indicators"
-//#endif
+#define INDICATOR_SERVICE_DIR "/usr/share/unity/indicators"
+#endif
+
+#if HAVE_AYATANA_INDICATOR && HAVE_AYATANA_INDICATOR_NG
+#include <libayatana-indicator/indicator-ng.h>
+
+#define INDICATOR_SERVICE_DIR "/usr/share/ayatana/indicators"
+#endif
 
 #if HAVE_UBUNTU_INDICATOR
 
@@ -566,8 +564,15 @@ static void load_indicator(GtkWidget *menubar, IndicatorObject *io, const gchar 
         indicator_object_set_environment(io, (const GStrv)indicator_env);
         g_debug("zzz load_indicator %s", name);
         /* Attach the 'name' to the object */
-        int pos = name2order(name);
 
+#if HAVE_AYATANA_INDICATOR_NG || HAVE_UBUNTU_INDICATOR_NG
+        int pos = 5000 - indicator_object_get_position(io);
+        if (pos > 5000) {
+                pos = name2order(name);
+        }
+#else
+        int pos = name2order(name);
+#endif
         g_object_set_data(G_OBJECT(io), IO_DATA_ORDER_NUMBER, GINT_TO_POINTER(pos));
 
         /* Connect to its signals */
@@ -604,7 +609,6 @@ static void load_indicator(GtkWidget *menubar, IndicatorObject *io, const gchar 
         g_list_free(entries);
 }
 
-/*
 #if HAVE_AYATANA_INDICATOR_NG || HAVE_UBUNTU_INDICATOR_NG
 void
 load_indicators_from_indicator_files (GtkWidget *menubar, gint *indicators_loaded)
@@ -653,8 +657,7 @@ load_indicators_from_indicator_files (GtkWidget *menubar, gint *indicators_loade
 
         g_dir_close (dir);
 }
-*/
-//#endif  /* HAVE_AYATANA_INDICATOR_NG || HAVE_UBUNTU_INDICATOR_NG */
+#endif  /* HAVE_AYATANA_INDICATOR_NG || HAVE_UBUNTU_INDICATOR_NG */
 
 static gboolean load_module(const gchar *name, GtkWidget *menubar)
 {

--- a/src/applet-main.c
+++ b/src/applet-main.c
@@ -26,12 +26,53 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
 
-//#include <libindicator/indicator-ng.h>
 #include <budgie-desktop/plugin.h>
+
+//#if HAVE_UBUNTU_INDICATOR && HAVE_UBUNTU_INDICATOR_NG
+//#include <libindicator/indicator-ng.h>
+//#include <libido/libido.h>
+//
+//#define INDICATOR_SERVICE_DIR "/usr/share/unity/indicators"
+//#endif
+
+//#if HAVE_AYATANA_INDICATOR && HAVE_AYATANA_INDICATOR_NG
+//#include <libayatana-indicator/indicator-ng.h>
+//#include <libayatana-ido/libayatana-ido.h>
+//
+//#define INDICATOR_SERVICE_DIR "/usr/share/ayatana/indicators"
+//#endif
+
+#if HAVE_UBUNTU_INDICATOR
+
+#define INDICATOR_SERVICE_APPMENU      "libappmenu.so"
+#define INDICATOR_SERVICE_ME           "libme.so"
+#define INDICATOR_SERVICE_DATETIME     "libdatetime.so"
+
+#define INDICATOR_SERVICE_APPMENU_NG   "com.canonical.indicator.appmenu"
+#define INDICATOR_SERVICE_ME_NG        "com.canonical.indicator.me"
+#define INDICATOR_SERVICE_DATETIME_NG  "com.canonical.indicator.datetime"
+
 #include <libindicator/indicator-object.h>
 
 static gchar *indicator_order[] = { "libapplication.so", "libmessaging.so", "libsoundmenu.so",
                                     "libdatetime.so",    "libsession.so",   NULL };
+#endif
+
+#if HAVE_AYATANA_INDICATOR
+
+#define INDICATOR_SERVICE_APPMENU      "libayatana-appmenu.so"
+#define INDICATOR_SERVICE_ME           "libayatana-me.so"
+#define INDICATOR_SERVICE_DATETIME     "libayatana-datetime.so"
+
+#define INDICATOR_SERVICE_APPMENU_NG   "org.ayatana.indicator.appmenu"
+#define INDICATOR_SERVICE_ME_NG        "org.ayatana.indicator.me"
+#define INDICATOR_SERVICE_DATETIME_NG  "org.ayatana.indicator.datetime"
+
+#include <libayatana-indicator/indicator-object.h>
+
+static gchar *indicator_order[] = { "libayatana-application.so", "libayatana-messaging.so", "libayatana-soundmenu.so",
+                                    "libayatana-datetime.so",    "libayatana-session.so",   NULL };
+#endif
 
 static gchar *blacklist_applets[] = { "nm-applet", 0 };
 
@@ -564,8 +605,7 @@ static void load_indicator(GtkWidget *menubar, IndicatorObject *io, const gchar 
 }
 
 /*
-#define INDICATOR_SERVICE_DIR "/usr/share/unity/indicators"
-
+#if HAVE_AYATANA_INDICATOR_NG || HAVE_UBUNTU_INDICATOR_NG
 void
 load_indicators_from_indicator_files (GtkWidget *menubar, gint *indicators_loaded)
 {
@@ -591,24 +631,15 @@ load_indicators_from_indicator_files (GtkWidget *menubar, gint *indicators_loade
                 indicator = indicator_ng_new_for_profile (filename, "desktop", &error);
                 g_free (filename);
 
-*#ifdef INDICATOR_APPLET_APPMENU
-                if (g_strcmp0(name, "com.canonical.indicator.appmenu")) {
+                if (!g_strcmp0(name, INDICATOR_SERVICE_APPMENU_NG)) {
                         continue;
                 }
-#else
-                if (!g_strcmp0(name, "com.canonical.indicator.appmenu")) {
+                if (!g_strcmp0(name, INDICATOR_SERVICE_ME_NG)) {
                         continue;
                 }
-#endif
-#ifdef INDICATOR_APPLET
-                if (!g_strcmp0(name, "com.canonical.indicator.me")) {
+                if (!g_strcmp0(name,  INDICATOR_SERVICE_DATETIME_NG)) {
                         continue;
                 }
-                if (!g_strcmp0(name, "com.canonical.indicator.datetime")) {
-                        continue;
-                }
-#endif
-*
                 if (indicator) {
                         load_indicator(menubar, INDICATOR_OBJECT (indicator), name);
                         count++;
@@ -623,6 +654,7 @@ load_indicators_from_indicator_files (GtkWidget *menubar, gint *indicators_loade
         g_dir_close (dir);
 }
 */
+//#endif  /* HAVE_AYATANA_INDICATOR_NG || HAVE_UBUNTU_INDICATOR_NG */
 
 static gboolean load_module(const gchar *name, GtkWidget *menubar)
 {
@@ -653,13 +685,13 @@ void load_modules(GtkWidget *menubar, gint *indicators_loaded)
                 const gchar *name;
                 gint count = 0;
                 while ((name = g_dir_read_name(dir)) != NULL) {
-                        if (!g_strcmp0(name, "libappmenu.so")) {
+                        if (!g_strcmp0(name, INDICATOR_SERVICE_APPMENU)) {
                                 continue;
                         }
-                        if (!g_strcmp0(name, "libme.so")) {
+                        if (!g_strcmp0(name, INDICATOR_SERVICE_ME)) {
                                 continue;
                         }
-                        if (!g_strcmp0(name, "libdatetime.so")) {
+                        if (!g_strcmp0(name, INDICATOR_SERVICE_DATETIME)) {
                                 continue;
                         }
                         g_debug("zzz a: %s", name);

--- a/src/applet.c
+++ b/src/applet.c
@@ -16,10 +16,20 @@
 
 #define _GNU_SOURCE
 
+#define <config.h>
+
 #include "applet.h"
 #include <assert.h>
 #include <budgie-desktop/plugin.h>
 #include <gobject/gobject.h>
+
+#if HAVE_UBUNTU_INDICATOR && HAVE_UBUNTU_INDICATOR_NG
+#include <libido/libido.h>
+#endif
+
+#if HAVE_AYATANA_INDICATOR && HAVE_AYATANA_INDICATOR_NG
+#include <libayatana-ido/libayatana-ido.h>
+#endif
 
 void load_modules(GtkWidget *menubar, gint *indicators_loaded);
 void load_indicators_from_indicator_files(GtkWidget *menubar, gint *indicators_loaded);
@@ -170,9 +180,9 @@ static void appindicator_applet_init(AppIndicatorApplet *self)
 {
         GtkCssProvider *css_provider = NULL;
 
-//#if HAVE_AYATANA_INDICATOR_NG || HAVE_UBUNTU_INDICATOR_NG
-//        ido_init();
-//#endif
+#if HAVE_AYATANA_INDICATOR_NG || HAVE_UBUNTU_INDICATOR_NG
+        ido_init();
+#endif
 
         menubar = gtk_menu_bar_new();
         self->menubar = menubar;
@@ -212,16 +222,9 @@ static void appindicator_applet_init(AppIndicatorApplet *self)
 
         gtk_icon_theme_append_search_path(gtk_icon_theme_get_default(), INDICATOR_ICONS_DIR);
 
-        /*
-         * leave this here - this is the entry point for indicators such as
-         * indicator-messages. Currently these indicators don't display their
-         * menu contents correctly - e.g. missing thunderbird from indicator-messages
-         * drop-down.
-         */
-
-//#if HAVE_AYATANA_INDICATOR_NG || HAVE_UBUNTU_INDICATOR_NG
-//      load_indicators_from_indicator_files (menubar, &indicators_loaded);
-//#endif
+#if HAVE_AYATANA_INDICATOR_NG || HAVE_UBUNTU_INDICATOR_NG
+        load_indicators_from_indicator_files (menubar, &indicators_loaded);
+#endif
 
         /* Show all of our things. */
         gtk_widget_show_all(GTK_WIDGET(self));

--- a/src/applet.c
+++ b/src/applet.c
@@ -170,6 +170,10 @@ static void appindicator_applet_init(AppIndicatorApplet *self)
 {
         GtkCssProvider *css_provider = NULL;
 
+//#if HAVE_AYATANA_INDICATOR_NG || HAVE_UBUNTU_INDICATOR_NG
+//        ido_init();
+//#endif
+
         menubar = gtk_menu_bar_new();
         self->menubar = menubar;
 
@@ -213,8 +217,11 @@ static void appindicator_applet_init(AppIndicatorApplet *self)
          * indicator-messages. Currently these indicators don't display their
          * menu contents correctly - e.g. missing thunderbird from indicator-messages
          * drop-down.
-         * load_indicators_from_indicator_files (menubar, &indicators_loaded);
          */
+
+//#if HAVE_AYATANA_INDICATOR_NG || HAVE_UBUNTU_INDICATOR_NG
+//      load_indicators_from_indicator_files (menubar, &indicators_loaded);
+//#endif
 
         /* Show all of our things. */
         gtk_widget_show_all(GTK_WIDGET(self));


### PR DESCRIPTION
Starting with DebConf 17 in Montreal, an initiative has come up to put the Indicators framework on independent feet. The initiative currently is mainly driven by a series of Debian and Ubuntu developers, esp. by the Debian+Ubuntu MATE Packaging team. But Ayatana Indicators is targetting to become available on all recent Linux distros, not only on Ubuntu.

Find attached two patches that (a) bring Ayatana Indicators [1] support to Budgie's indicator applet and (b) re-enable NG indicator support again (it worked nicely in my tests on Debian unstable).

Please also see my bug report on Debian BTS:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=893707

